### PR TITLE
Separately Configurable Stroke & Fill Colours

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -22,11 +22,12 @@ All code lives in the `OsmAirportGenerator` directory. There are four code files
     * It takes user input.
     * It queries [Overpass](https://overpass-turbo.eu/) to get necessary data.
     * It creates a temporary folder for generator output.
-    * It determines which generators should be run and calls them.
+    * It calls the generators.
     * It collates and packages generator output files.
 * `Generators.cs` contains the actual generators.
     * A generator is a method that converts Overpass data into Aurora-readable files.
     * Generators are run sequentially and relevant outputs are concatenated in order.
+    * Generators are given a copy of the configuration and are responsible for suppressing their own output if required.
     * Generators are responsible for filtering the full Overpass data into just the information they need.
 * `Utils.cs` contains helper methods that keep the other files readable.
     * Each helper method uses [C# documentation comments](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) to describe its behaviour.

--- a/OsmAirportGenerator/Config.cs
+++ b/OsmAirportGenerator/Config.cs
@@ -4,15 +4,15 @@ namespace OsmAirportGenerator;
 
 internal record Config(
 	[property: JsonPropertyName("termsAccepted")] bool TermsAccepted,
-	[property: JsonPropertyName("colours")] Colourscheme Colours,
+	[property: JsonPropertyName("colours")] ColourschemeSet Colours,
 	[property: JsonPropertyName("visibility")] Visibility Visibility,
 	[property: JsonPropertyName("inflation")] Inflation Inflation
 )
 {
 	public static Config Default { get; } = new(
 		false,
-		new Colourscheme(null, null, null, null, null, null, null).Normalise(),
-		new Visibility(null, null, null, null, null, null, null).Normalise(),
+		ColourschemeSet.Default,
+		Visibility.Empty.Normalise(),
 		new Inflation(null, null).Normalise()
 	); 
 
@@ -21,6 +21,22 @@ internal record Config(
 		Colours.Normalise(),
 		Visibility.Normalise(),
 		Inflation.Normalise()
+	);
+}
+
+internal record ColourschemeSet(
+	[property: JsonPropertyName("fill")] Colourscheme Fill,
+	[property: JsonPropertyName("stroke")] Colourscheme Stroke
+)
+{
+	public static ColourschemeSet Default { get; } = new(
+		Colourscheme.Empty.Normalise(),
+		Colourscheme.Empty.Normalise()
+	);
+	
+	public ColourschemeSet Normalise() => new(
+		Fill.Normalise(),
+		Stroke.Normalise()
 	);
 }
 
@@ -34,6 +50,8 @@ internal record Colourscheme(
 	[property: JsonPropertyName("runway")] string? Runway
 )
 {
+	public static Colourscheme Empty { get; } = new(null, null, null, null, null, null, null);
+
 	public Colourscheme Normalise() => new(
 		Boundary ?? "BOUNDARY",
 		Apron ?? "APRON",
@@ -55,6 +73,8 @@ internal record Visibility(
 	[property: JsonPropertyName("runway")] bool? Runway
 )
 {
+	public static Visibility Empty { get; } = new(null, null, null, null, null, null, null);
+
 	public Visibility Normalise() => new(
 		Boundary ?? false,
 		Apron ?? true,

--- a/OsmAirportGenerator/Generators.cs
+++ b/OsmAirportGenerator/Generators.cs
@@ -6,8 +6,11 @@ internal static partial class GenerationUtils
 {
 	/// <summary>Generates a big, ugly poly filling any aerodrome boundaries.</summary>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
-	public static async Task GenerateBoundaryAsync(string filePrefix, Overpass data, string fillColour)
+	public static async Task GenerateBoundaryAsync(string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Boundary is false)
+			return;
+
 		// Get the TFL writer and filter the provided data to just the bits we care about.
 		string filePath = Path.ChangeExtension(filePrefix, @"tfl");
 		var filteredData = data.Filter(static i => i["aeroway"] is "aerodrome");
@@ -15,13 +18,16 @@ internal static partial class GenerationUtils
 
 		// Add all the TFLs for all the boundaries.
 		foreach (Way boundary in filteredData.AllWays())
-			await fileWriter.WriteLineAsync(boundary.ToTfl(fillColour));
+			await fileWriter.WriteLineAsync(boundary.ToTfl(config.Colours.Fill.Boundary!, config.Colours.Stroke.Boundary!));
 	}
 
 	/// <summary>Generates polys for any provided terminals, hangars, and towers.</summary>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
-	public static async Task GenerateBuildingsAsync(string airport, string filePrefix, Overpass data, string fillColour)
+	public static async Task GenerateBuildingsAsync(string airport, string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Building is false)
+			return;
+
 		// Get the TFL writer and filter the provided data to just the bits we care about.
 		string polyFilePath = Path.ChangeExtension(filePrefix, @"tfl");
 		string labelFilePath = Path.ChangeExtension(filePrefix, @"txi");
@@ -33,7 +39,7 @@ internal static partial class GenerationUtils
 
 		// Add all the TFLs for all the buildings.
 		foreach (Way building in allWays)
-			await polyWriter.WriteLineAsync(building.ToTfl(fillColour, "BUILDING"));
+			await polyWriter.WriteLineAsync(building.ToTfl(config.Colours.Fill.Building!, config.Colours.Stroke.Building!, "BUILDING"));
 
 		// Add labels for the buildings which have them.
 		foreach (Way building in allWays.Where(static w => (w["ref"] ?? w["name"]) is not null))
@@ -42,22 +48,28 @@ internal static partial class GenerationUtils
 
 	/// <summary>Generates polys for any provided aprons.</summary>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
-	public static async Task GenerateApronsAsync(string filePrefix, Overpass data, string fillColour)
+	public static async Task GenerateApronsAsync(string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Apron is false)
+			return;
+
 		// Get the TFL writer and filter the provided data to just the bits we care about.
 		string filePath = Path.ChangeExtension(filePrefix, @"tfl");
 		var filteredData = data.Filter(static i => i["aeroway"] is "apron");
 		using StreamWriter fileWriter = await GetWriterAsync(filePath);
 
 		foreach (Way apronArea in filteredData.AllWays())
-			await fileWriter.WriteLineAsync(apronArea.ToTfl(fillColour, "APRON"));
+			await fileWriter.WriteLineAsync(apronArea.ToTfl(config.Colours.Fill.Apron!, config.Colours.Stroke.Apron!, "APRON"));
 	}
 
 	/// <summary>Generates centrelines for any provided taxilanes.</summary>
 	/// <param name="airport">The ICAO code of the airport being generated.</param>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
-	public static async Task GenerateTaxilanesAsync(string filePrefix, Overpass data, string strokeColour)
+	public static async Task GenerateTaxilanesAsync(string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Taxilane is false)
+			return;
+
 		// Get the GEO writer and filter the provided data to just the bits we care about.
 		string filePath = Path.ChangeExtension(filePrefix, @"geo");
 		var filteredData = data.Filter(static i => i["aeroway"] is "taxilane");
@@ -66,15 +78,18 @@ internal static partial class GenerationUtils
 		// NOTE: We're not unpacking relations here.
 		// That would imply someone went and surrounded the taxilane instead of just drawing its centreline.
 		foreach (Way taxilane in filteredData.Ways.Values)
-			await fileWriter.WriteLineAsync(taxilane.ToGeo(strokeColour));
+			await fileWriter.WriteLineAsync(taxilane.ToGeo(config.Colours.Stroke.Taxilane!));
 	}
 
 	/// <summary>Generates centrelines & polys for any provided taxiways.</summary>
 	/// <param name="airport">The ICAO code of the airport being generated.</param>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
 	/// <param name="inflation">The amount to inflate the centreline by to make the polygon.</param>
-	public static async Task GenerateTaxiwaysAsync(string airport, string filePrefix, Overpass data, string strokeColour, string fillColour, double inflation = 0.0001)
+	public static async Task GenerateTaxiwaysAsync(string airport, string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Taxiway is false)
+			return;
+
 		// Get the writers and filter the provided data to just the bits we care about.
 		string centrelineFilePath = Path.ChangeExtension(filePrefix, @"geo");
 		string polyFilePath = Path.ChangeExtension(filePrefix, @"tfl");
@@ -87,11 +102,11 @@ internal static partial class GenerationUtils
 		Way[] allWays = [..filteredData.AllWays()];
 
 		foreach (Way taxiway in allWays)
-			await centrelineWriter.WriteLineAsync(taxiway.ToGeo(strokeColour));
+			await centrelineWriter.WriteLineAsync(taxiway.ToGeo(config.Colours.Stroke.Taxiway!));
 
 		// Inflate the centrelines by the given amount and render them out.
-		foreach (Way taxiwayBoundary in allWays.Select(w => w.Inflate(inflation)))
-			await polyWriter.WriteLineAsync(taxiwayBoundary.ToTfl(fillColour, "TAXIWAY"));
+		foreach (Way taxiwayBoundary in allWays.Select(w => w.Inflate(config.Inflation.Taxiway ?? 0.0001)))
+			await polyWriter.WriteLineAsync(taxiwayBoundary.ToTfl(config.Colours.Fill.Taxiway!, config.Colours.Stroke.Taxiway!, "TAXIWAY"));
 
 		// Generate the taxiway labels.
 		await labelWriter.WriteLineAsync(allWays.LabelCentrelines(airport));
@@ -100,28 +115,34 @@ internal static partial class GenerationUtils
 	/// <summary>Generates polys for any provided runways.</summary>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
 	/// <param name="inflation">The amount to inflate the centreline by to make the polygon.</param>
-	public static async Task GenerateRunwaysAsync(string filePrefix, Overpass data, string fillColour, double inflation = 0.0002)
+	public static async Task GenerateRunwaysAsync(string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Runway is false)
+			return;
+
 		// Get the TFL writer and filter the provided data to just the bits we care about.
 		string filePath = Path.ChangeExtension(filePrefix, @"tfl");
 		var filteredData = data.Filter(static i => i["aeroway"] is "runway");
 		using StreamWriter fileWriter = await GetWriterAsync(filePath);
 
 		// Inflate the centrelines by the given amount and render them out.
-		foreach (Way runwayBoundary in filteredData.AllWays().Select(w => w.Inflate(inflation)))
-			await fileWriter.WriteLineAsync(runwayBoundary.ToTfl(fillColour, "RUNWAY"));
+		foreach (Way runwayBoundary in filteredData.AllWays().Select(w => w.Inflate(config.Inflation.Runway ?? 0.0002)))
+			await fileWriter.WriteLineAsync(runwayBoundary.ToTfl(config.Colours.Fill.Runway!, config.Colours.Stroke.Runway!, "RUNWAY"));
 	}
 
 	/// <summary>Generates polys for any provided helipads.</summary>
 	/// <param name="filePrefix">The folder & filename to output the generated files into. File extension will be replaced.</param>
-	public static async Task GenerateHelipadsAsync(string filePrefix, Overpass data, string fillColour)
+	public static async Task GenerateHelipadsAsync(string filePrefix, Overpass data, Config config)
 	{
+		if (config.Visibility.Helipad is false)
+			return;
+
 		// Get the TFL writer and filter the provided data to just the bits we care about.
 		string filePath = Path.ChangeExtension(filePrefix, @"tfl");
 		var filteredData = data.Filter(static i => i["aeroway"] is "helipad");
 		using StreamWriter fileWriter = await GetWriterAsync(filePath);
 
 		foreach (Way helipad in filteredData.AllWays())
-			await fileWriter.WriteLineAsync(helipad.ToTfl(fillColour, "RUNWAY"));
+			await fileWriter.WriteLineAsync(helipad.ToTfl(config.Colours.Fill.Helipad!, config.Colours.Stroke.Helipad!, "RUNWAY"));
 	}
 }

--- a/OsmAirportGenerator/Program.cs
+++ b/OsmAirportGenerator/Program.cs
@@ -13,7 +13,8 @@ if (File.Exists("config.json"))
 {
 	if (System.Text.Json.JsonSerializer.Deserialize<Config>(File.ReadAllText("config.json")) is not Config deserialisedConfig)
 	{
-		Console.Error.WriteLine("Invalid configuration file.");
+		File.Move("config.json", "config.broken.json");
+		Console.Error.WriteLine("Invalid configuration file. Moved to config.broken.json. Next time this program is run, a clean file will be generated.");
 		Environment.Exit(-1);
 		return;
 	}
@@ -100,26 +101,13 @@ out;", timeoutMins: 6);
 	System.Globalization.CultureInfo.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
 
 	// Generate the necessary files.
-	if (config.Visibility.Boundary!.Value)
-		await GenerateBoundaryAsync(filePrefix, data, config.Colours.Boundary!);
-
-	if (config.Visibility.Apron!.Value)
-		await GenerateApronsAsync(filePrefix, data, config.Colours.Apron!);
-
-	if (config.Visibility.Building!.Value)
-		await GenerateBuildingsAsync(airportIcao, filePrefix, data, config.Colours.Building!);
-
-	if (config.Visibility.Taxilane!.Value)
-		await GenerateTaxilanesAsync(filePrefix, data, config.Colours.Taxilane!);
-
-	if (config.Visibility.Taxiway!.Value)
-		await GenerateTaxiwaysAsync(airportIcao, filePrefix, data, config.Colours.Taxiway!, config.Colours.Taxiway!, config.Inflation.Taxiway!.Value);
-
-	if (config.Visibility.Helipad!.Value)
-		await GenerateHelipadsAsync(filePrefix, data, config.Colours.Helipad!);
-
-	if (config.Visibility.Runway!.Value)
-		await GenerateRunwaysAsync(filePrefix, data, config.Colours.Runway!, config.Inflation.Runway!.Value);
+	await GenerateBoundaryAsync(filePrefix, data, config);
+	await GenerateApronsAsync(filePrefix, data, config);
+	await GenerateBuildingsAsync(airportIcao, filePrefix, data, config);
+	await GenerateTaxilanesAsync(filePrefix, data, config);
+	await GenerateTaxiwaysAsync(airportIcao, filePrefix, data, config);
+	await GenerateHelipadsAsync(filePrefix, data, config);
+	await GenerateRunwaysAsync(filePrefix, data, config);
 
 	System.Globalization.CultureInfo.CurrentCulture = cultureCache;
 	Console.WriteLine("Done!");

--- a/OsmAirportGenerator/Utils.cs
+++ b/OsmAirportGenerator/Utils.cs
@@ -12,12 +12,13 @@ internal static partial class GenerationUtils
 {
 	/// <summary>Converts a given <see cref="Way"/> to an Aurora-readable TFL block with a given colour and, optionally, filter.</summary>
 	/// <param name="way">The <see cref="Way"/> to render.</param>
-	/// <param name="colour">The colour which should be put (verbatim) into the sectorfile.</param>
+	/// <param name="fillColour">The colour which should be put (verbatim) into the "fill" colour section of the TFL header in the sectorfile.</param>
+	/// <param name="strokeColour">The colour which should be put (verbatim) into the "stroke" colour section of the TFL header in the sectorfile.</param>
 	/// <param name="filter">Optionally, one of	COAST, RUNWAY, GATES, PIER, TAXIWAY, APRON, BUILDING.</param>
 	/// <returns>A string containing the whole TFL block, ending with a newline.</returns>
-	private static string ToTfl(this Way way, string colour, string? filter = null)
+	private static string ToTfl(this Way way, string fillColour, string strokeColour, string? filter = null)
 	{
-		StringBuilder builder = new($"STATIC;{colour};1;{colour};0;");
+		StringBuilder builder = new($"STATIC;{fillColour};1;{strokeColour};0;");
 		builder.AppendLine(filter is null ? "" : filter);
 
 		foreach (Node node in way.Nodes)


### PR DESCRIPTION
Closes #1.

Splits the `colours` member of the config object into a new `ColourschemeSet` type containing two `Colourscheme`s (`stroke` and `fill`). The generators have been altered to take the whole config object and use the right colours accordingly.